### PR TITLE
Add more shopping_list tests

### DIFF
--- a/spec/shopping_list_spec.rb
+++ b/spec/shopping_list_spec.rb
@@ -6,8 +6,15 @@ RSpec.describe 'GET /shopping_list' do
 
   let(:app) { Application }
 
-  it 'returns 200'
-  it 'gives an empty shopping list'
+  it 'returns 200' do
+    get '/shopping_list'
+    expect(last_response.status).to eq 200
+  end
+
+  it 'gives an empty shopping list' do
+    get '/shopping_list'
+    expect(ListItem.all).to be_empty
+  end
 
   context 'with some list items' do
     let(:list_item_names) { ['cheese sticks', 'bubbles'] }


### PR DESCRIPTION
Filling in some more of our pending tests for `/shopping_list` to return 200 and give an empty shopping list when we haven't created any list items.