### PR TITLE
add a `List` class with association to `ListItems` 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7-alpine
 
 RUN apk update && \
-    apk add build-base libc-dev git postgresql postgresql-dev
+    apk add bash build-base libc-dev git postgresql postgresql-dev
 
 RUN gem update bundler
 

--- a/lib/models/list.rb
+++ b/lib/models/list.rb
@@ -1,0 +1,3 @@
+class List < Sequel::Model
+  many_to_many :list_items
+end

--- a/migrations/202006140_create_lists.rb
+++ b/migrations/202006140_create_lists.rb
@@ -1,0 +1,10 @@
+Sequel.migration do
+  change do
+    create_table :lists do
+      primary_key :id
+      String :name
+    end
+
+    create_join_table(list_id: :lists, list_item_id: :list_items)
+  end
+end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,0 +1,36 @@
+require './spec/spec_helper'
+
+RSpec.describe List do
+  subject(:list) { described_class.new }
+
+  describe '#name' do
+    let(:name) { 'my list' }
+
+    it 'can assign a name' do
+      expect { list.name = name }
+        .to change { list.name }
+        .from(nil)
+        .to name
+    end
+
+    context 'when the name is defined on initialization' do
+      subject(:list) { described_class.new(name: name) }
+
+      it { is_expected.to have_attributes name: name }
+    end
+  end
+
+  describe '#list_items' do
+    let(:items) do
+      [ListItem.create(name: 'cheese sticks'),
+       ListItem.create(name: 'bubbles')]
+    end
+
+    it 'can assign multiple list items' do
+      expect { items.each { |i| list.list_items << i } }
+        .to change { list.list_items }
+        .from(be_empty)
+        .to contain_exactly(*items)
+    end
+  end
+end


### PR DESCRIPTION
adds a model `List` with a join table for a many-to-many relation to the
existing `ListItem`. recall that the database migrations are running on startup,
so our schema should stay up-to-date across environments.