### PR TITLE
add `racksh` for an easy application console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 gem 'database_cleaner-sequel', '~> 1.8', group: %w[test]
 gem 'sequel', '~> 5.33'
 gem 'sinatra', '~> 2.0.8'
+gem 'racksh', '~> 1.0'
 gem 'rspec', '~> 3.9', group: %w[development]
 gem 'pg', '~> 1.2'
 gem 'pry', group: %w[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,9 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    racksh (1.0.0)
+      rack (>= 1.0)
+      rack-test (>= 0.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -49,6 +52,7 @@ DEPENDENCIES
   pg (~> 1.2)
   pry
   rack-test
+  racksh (~> 1.0)
   rspec (~> 3.9)
   sequel (~> 5.33)
   sinatra (~> 2.0.8)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ docker-compose build
 docker-compose up
 ```
 
+You can now get an application console with `docker-compose exec web racksh`.
+
 ### Running the tests
 
 To run the tests in a docker-compose environment, do:


### PR DESCRIPTION
this avoids needing to require the application and the bundle when starting a
console. the `racksh` gem is added to all the bundle groups because it will be
handy to have this available in a production deployment, as well as the
development env.