### PR TITLE
make docker entrypoint sensitive to environment variables

### DIFF
--- a/bin/witchcult-shop.sh
+++ b/bin/witchcult-shop.sh
@@ -8,5 +8,5 @@ do
 done
 
 echo "Connecting to postgresql"
-bundle exec sequel -m ./migrations postgres://psql:postgres-devel@postgres:5432/witchcult-shops
+bundle exec sequel -m ./migrations postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB
 bundle exec rackup -o 0.0.0.0 -p 9000


### PR DESCRIPTION
we hardcoded the postgres connection details, but these will vary across environments. use the existing environment variables instead.

unfortunately, our github actions setup won't test this since these are also hard-coded there. i'm not sure how to get actions to pull environment variables, so i've opened a ticket to address at #31 